### PR TITLE
Add link to previous run in LiveRunPage

### DIFF
--- a/src/components/EMS/CompletedRunsTable.tsx
+++ b/src/components/EMS/CompletedRunsTable.tsx
@@ -20,12 +20,7 @@ const CompletedRunsTable = ({
   const prevTableEntries = React.useRef<typeof tableEntries>();
 
   React.useEffect(() => {
-    if (
-      prevTableEntries.current?.length &&
-      prevTableEntries.current[0]?.node?.name !== tableEntriesFromProps &&
-      tableEntriesFromProps?.length &&
-      tableEntriesFromProps[0]?.node?.name
-    ) {
+    if (prevTableEntries.current?.length && tableEntriesFromProps?.length) {
       setTableEntries([...prevTableEntries.current, ...tableEntriesFromProps]);
     }
   }, [tableEntriesFromProps]);
@@ -72,7 +67,7 @@ const CompletedRunsTable = ({
       </div>
       {pageInfo?.hasNextPage && (
         <Button
-          className="px-4 py-2 mt-5"
+          className="mt-5"
           onClick={() => {
             prevTableEntries.current = tableEntries;
             setCursor(pageInfo?.endCursor || null);

--- a/src/components/EMS/HistogramChart/HistogramChart.tsx
+++ b/src/components/EMS/HistogramChart/HistogramChart.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import {
   LineChart,
   Line,
@@ -9,6 +8,7 @@ import {
   ReferenceArea,
   ResponsiveContainer,
 } from "recharts";
+import { CategoricalChartState } from "recharts/types/chart/generateCategoricalChart";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearchMinus } from "@fortawesome/free-solid-svg-icons";
 import { Histogram, LiveHistogram } from "generated";
@@ -61,7 +61,8 @@ const HistogramChart = ({ histogram }: Props) => {
         <Button
           disabled={!canZoom}
           type="button"
-          className={clsx("px-4", "py-2", "mx-3", "my-3")}
+          size="sm"
+          className="m-3"
           onClick={() => zoomOut()}
         >
           <FontAwesomeIcon icon={faSearchMinus} /> Reset Zoom
@@ -73,8 +74,8 @@ const HistogramChart = ({ histogram }: Props) => {
           width={800}
           height={400}
           data={data}
-          onMouseDown={e => {
-            if (e.activeLabel) setRefAreaLeft(parseInt(e.activeLabel));
+          onMouseDown={(e: CategoricalChartState | null) => {
+            if (e?.activeLabel) setRefAreaLeft(parseInt(e.activeLabel));
           }}
           onMouseMove={e => {
             if (e.activeLabel && refAreaLeft) {

--- a/src/components/EMS/LiveRun.graphql
+++ b/src/components/EMS/LiveRun.graphql
@@ -1,24 +1,27 @@
 subscription getAllLiveHistograms {
   getLiveHistograms {
-    id
-    name
-    created
-    type
-    data {
-      x
-      y
+    histograms {
+      id
+      name
+      created
+      type
+      data {
+        x
+        y
+      }
+      xrange {
+        min
+        max
+      }
+      yrange {
+        min
+        max
+      }
+      current {
+        x
+        y
+      }
     }
-    xrange {
-      min
-      max
-    }
-    yrange {
-      min
-      max
-    }
-    current {
-      x
-      y
-    }
+    lastRun
   }
 }

--- a/src/components/EMS/LiveRun.tsx
+++ b/src/components/EMS/LiveRun.tsx
@@ -3,6 +3,7 @@ import { useSubscription } from "urql";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHourglassEnd } from "@fortawesome/free-solid-svg-icons";
 
+import Link from "components/shared/Link";
 import {
   GetAllLiveHistogramsDocument,
   GetAllLiveHistogramsSubscription,
@@ -10,12 +11,10 @@ import {
 import HistogramChart from "./HistogramChart";
 
 const handleSubscription = (
-  _liveHistograms: GetAllLiveHistogramsSubscription["getLiveHistograms"] = [],
+  _liveHistograms: GetAllLiveHistogramsSubscription["getLiveHistograms"] = {},
   response: GetAllLiveHistogramsSubscription,
 ) => {
-  const incomingHistograms = response?.getLiveHistograms
-    ? response?.getLiveHistograms
-    : [];
+  const incomingHistograms = response?.getLiveHistograms ?? null;
   return incomingHistograms;
 };
 
@@ -27,7 +26,10 @@ const LiveRun = () => {
     handleSubscription,
   );
 
-  const liveHistograms = result.data;
+  const liveHistograms = result.data?.histograms?.length
+    ? result.data?.histograms
+    : [];
+  const lastRun = result.data?.lastRun;
 
   if (!liveHistograms?.length) {
     return (
@@ -37,9 +39,15 @@ const LiveRun = () => {
             className="text-dark-blue dark:text-slate-300 mx-4 my-8 fa-4x"
             icon={faHourglassEnd}
           />
-          <p className="text-slate-400 font-medium text-sm md:text-xl lg:text-2xl mt-8">
+          <p className="text-slate-400 text-2xl lg:text-4xl dark:text-white font-medium md:text-xl mt-8">
             No Histograms are currently running.
           </p>
+          {lastRun ? (
+            <p className="dark:text-slate-400 font-medium text-sm md:text-xl lg:text-2xl mt-8">
+              Click <Link to={`/ems/${lastRun}`}>here </Link>
+              to view the most recent run.
+            </p>
+          ) : null}
         </div>
       </div>
     );

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -4,19 +4,22 @@ import useDarkMode from "hooks/useDarkMode";
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children: React.ReactNode;
+  size?: "xs" | "tiny" | "sm" | "md" | "lg";
   className?: string;
 };
 
-const Button = ({ children, className, ...props }: Props) => {
+const Button = ({ children, className, size = "md", ...props }: Props) => {
   const [isDark] = useDarkMode();
+
   return (
     <button
       type="button"
       className={clsx(
         "text-white",
         "font-bold",
-        "uppercase",
-        "text-xs",
+        `text-${size}`,
+        "px-4",
+        "py-2",
         "rounded",
         "shadow",
         "hover:shadow-md",
@@ -27,8 +30,9 @@ const Button = ({ children, className, ...props }: Props) => {
         "duration-150",
         "disabled:bg-gray-400",
         "disabled:cursor-not-allowed",
-        isDark ? "bg-blue-800" : "bg-blue-600",
-        isDark ? "hover:bg-blue-900" : "hover:bg-blue-700",
+        isDark ? "bg-blue-700" : "bg-blue-600",
+        isDark ? "hover:bg-blue-900" : "hover:bg-blue-800",
+
         className,
       )}
       {...props}

--- a/src/components/shared/Link.tsx
+++ b/src/components/shared/Link.tsx
@@ -1,0 +1,22 @@
+import clsx from "clsx";
+import { Link as ReactRouterLink, LinkProps } from "react-router-dom";
+
+type Props = LinkProps & {
+  to: string;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const Link = ({ to, children, className, ...props }: Props) => {
+  return (
+    <ReactRouterLink
+      to={to}
+      className={clsx("text-blue-500", "dark:text-white", "className")}
+      {...props}
+    >
+      {children}
+    </ReactRouterLink>
+  );
+};
+
+export default Link;


### PR DESCRIPTION
Adds a link to the previous run in the Live Run Page when live run is not active.

![image](https://user-images.githubusercontent.com/13325070/173207077-c2f5f6cd-0820-495a-9831-a7a7cf55afc8.png)

Other Changes
- Adds standardized `Button` sizes
- Adds a standardized `Link` and css styles derived from react-router's `Link` component

Dependencies
BE PR https://github.com/dougUCN/LANE-server/pull/11 must be merged first.