### PR TITLE
ESLint - Only allow unused vars with a _ prefix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,9 +109,9 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": [
       "warn", // or error
       {
-        argsIgnorePattern: "^_*",
-        varsIgnorePattern: "^_*",
-        caughtErrorsIgnorePattern: "^_*",
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
       },
     ],
     "no-use-before-define": "off",

--- a/src/components/RunConfig/RunConfigItem/LoadRunConfigModal.tsx
+++ b/src/components/RunConfig/RunConfigItem/LoadRunConfigModal.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { CombinedError, useMutation } from "urql";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faWarning } from "@fortawesome/free-solid-svg-icons";
 
 import { Button, Modal } from "components/shared";
 import { LoadRunConfigDocument, RunConfig } from "generated";

--- a/src/components/shared/CheckboxField.tsx
+++ b/src/components/shared/CheckboxField.tsx
@@ -84,6 +84,7 @@ const CheckboxField = (
             <input
               {...register}
               {...props}
+              {...ref}
               type="checkbox"
               value={option.value}
               checked={checkedOptions.includes(option.value)}

--- a/src/components/shared/Dropdown.tsx
+++ b/src/components/shared/Dropdown.tsx
@@ -60,6 +60,7 @@ const Dropdown = (
       ) : null}
       <select
         {...register}
+        {...ref}
         className={clsx(
           "bg-gray-50 border",
           "border-gray-300",

--- a/src/components/shared/TextField.tsx
+++ b/src/components/shared/TextField.tsx
@@ -51,6 +51,7 @@ const TextField = (
       ) : null}
       <input
         {...register}
+        {...ref}
         type="text"
         className={clsx(
           "bg-gray-50 border",


### PR DESCRIPTION
Bug: Unused vars without an `_` prefix were not being caught. 

Fix: Update the regex to ensure that variables declared without a `_` prefix must be used.