### PR TITLE
Add production deployment scripts and configuration files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,8 @@ To update the production client, perform the following:
 
 This will pause the production client, check for updates, rebuild the client, and redeploy.
 
+**Note:** Changes to the `deploy-prod/lane.conf` file will not propagate to the actual Nginx config file located in production. This needs to be done manually
+
 The steps for setting up the client on the LANL production server for the first time are as follows:
 
 1. Make sure that the production backend server has been deployed as described [here](https://github.com/dougUCN/LANE-server)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,26 +101,26 @@ The github actions for CI on AWS will ssh into the EC2 instance, run `git pull` 
 
 ### Production
 
-As of 12/15/2022, the production client may only be accessed on the LANL OCE network at http://nedm-macpro.lanl.gov. (Note that LANE currently only supports `http` not `https`)
+As of 12/15/2022, the production LANE-client may only be accessed on the LANL OCE network at http://nedm-macpro.lanl.gov. (Note that LANE currently only supports `http` not `https`)
 
-To update the production client, perform the following:
+To update the production LANE-client, perform the following:
 
 1. Update the server on production as per the instructions [here](https://github.com/dougUCN/LANE-server)
 2. Run the `deploy.sh` script located in `$HOME/LANE/LANE-client/deploy-prod`
 
 ```bash
-# Assuming you are in the LANE-client directory
+# Assuming you are in the $HOME/LANE/LANE-client directory
 chmod u+x deploy-prod/deploy.sh
 ./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
 ```
 
-This will pause the production client, check for updates, rebuild the client, and redeploy.
+This will pause the production LANE-client, check for updates, rebuild, and redeploy.
 
 **Note:** Changes to the `deploy-prod/lane.conf` file will not propagate to the actual Nginx config file located in production. This needs to be done manually
 
-The steps for setting up the client on the LANL production server for the first time are as follows:
+The steps for setting up the LANE-client on the LANL production server for the first time are as follows:
 
-1. Make sure that the production backend server has been deployed as described [here](https://github.com/dougUCN/LANE-server)
+1. Make sure that the production backend server has been deployed as described in the `CONTRIBUTING.md` file [here](https://github.com/dougUCN/LANE-server)
 2. In the folder `$HOME/LANE`, run `git clone https://github.com/dougUCN/LANE-client.git`. (The server repo should be cloned into the same folder). Your directory structure should look as follows:
 
 ```
@@ -177,3 +177,5 @@ chmod u+x deploy-prod/deploy.sh
 ```
 
 14. Get the pm2 process manager to run at startup as per the instructions [here](https://pm2.keymetrics.io/docs/usage/startup/)
+
+The LANE client should now be accessible at http://nedm-macpro.lanl.gov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ systemctl status nginx # Check nginx status
 
 9.  Copy the contents of the file `/deploy-prod/lane.conf` to the nginx config file at `etc/nginx/conf.d`.
 10. If there is a file `/nginx/sites-enabled/default`, either delete the file or move it to the folder `/nginx/sites-available`
-11. If ufw is enabled, modify firewall rules with the command `sudo ufw allow 'Nginx Full'` (ONLY if ufw is enabled. By default on the production server it was not.)
+11. If ufw is enabled, modify firewall rules with the command `sudo ufw allow 'Nginx Full'` (Only perform this step if ufw is enabled. By default on the production server it was not. View ufw status with `sudo ufw status verbose`.)
 12. Restart nginx with `sudo systemctl restart nginx`
 13. Run the deploy shell script
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ To update the production LANE-client, perform the following:
 ```bash
 # Assuming you are in the $HOME/LANE/LANE-client directory
 chmod u+x deploy-prod/deploy.sh
-./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
+./deploy-prod/deploy.sh
 ```
 
 This will pause the production LANE-client, check for updates, rebuild, and redeploy.
@@ -173,7 +173,7 @@ systemctl status nginx # Check nginx status
 ```bash
 # Assuming you are in the LANE-client directory
 chmod u+x deploy-prod/deploy.sh
-./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
+./deploy-prod/deploy.sh
 ```
 
 14. Get the pm2 process manager to run at startup as per the instructions [here](https://pm2.keymetrics.io/docs/usage/startup/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,12 @@ To update the production client, perform the following:
 1. Update the server on production as per the instructions [here](https://github.com/dougUCN/LANE-server)
 2. Run the `deploy.sh` script located in `$HOME/LANE/LANE-client/deploy-prod`
 
+```bash
+# Assuming you are in the LANE-client directory
+chmod u+x deploy-prod/deploy.sh
+./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
+```
+
 This will pause the production client, check for updates, rebuild the client, and redeploy.
 
 **Note:** Changes to the `deploy-prod/lane.conf` file will not propagate to the actual Nginx config file located in production. This needs to be done manually

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -1,26 +1,4 @@
-#!/bin/bash
-
-echo "Kill all the running PM2 actions"
-pm2 kill
-
-echo "Jump to app folder"
-cd $HOME/LANE-client
-pwd
-
-echo "Check for any dependency updates"
-NPM_DEPENDENCIES_UPDATED=($(git diff --name-only HEAD HEAD~1 | grep "^package.*json$"))
-if [[ "$NPM_DEPENDENCIES_UPDATED" != "" ]]; then
-    echo "Reinstalling depdenencies"
-    rm -rf node_modules
-    npm ci
-else
-    echo "No new dependencies found"
-fi
-
-echo "Generate typescript from Railway endpoint"
-npm run generate:staging
-
-echo "Create .env.local file with Railway endpoint URLs"
+URLs"
 printf 'VITE_GRAPHQL_HTTP_ENDPOINT="https://lane-staging.up.railway.app/graphql/"\nVITE_GRAPHQL_WS_ENDPOINT="ws://lane-staging.up.railway.app/graphql/"' > '.env.local'
 
 echo "Build app"

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -1,4 +1,25 @@
-URLs"
+#!/bin/bash
+
+echo "Kill all the running PM2 actions"
+pm2 kill
+
+echo "Jump to app folder"
+cd $HOME/LANE-client
+pwd
+
+echo "Check for any dependency updates"
+NPM_DEPENDENCIES_UPDATED=($(git diff --name-only HEAD HEAD~1 | grep "^package.*json$"))
+if [[ "$NPM_DEPENDENCIES_UPDATED" != "" ]]; then
+    echo "Reinstalling depdenencies"
+    npm ci
+else
+    echo "No new dependencies found"
+fi
+
+echo "Generate typescript from Railway endpoint"
+npm run generate:staging
+
+echo "Create .env.local file with Railway endpoint URLs"
 printf 'VITE_GRAPHQL_HTTP_ENDPOINT="https://lane-staging.up.railway.app/graphql/"\nVITE_GRAPHQL_WS_ENDPOINT="ws://lane-staging.up.railway.app/graphql/"' > '.env.local'
 
 echo "Build app"

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "Kill all the running PM2 actions"
+pm2 kill
+
+echo "Jump to app folder"
+cd $HOME/LANE/LANE-client
+pwd
+
+git pull
+
+echo "Reinstalling dependencies"
+rm -rf node_modules
+npm ci
+
+echo "Generate typescript from local files"
+npm run generate:local
+
+echo "Create .env.local file with production endpoint URLs"
+printf 'VITE_GRAPHQL_HTTP_ENDPOINT="http://nedm-macpro.lanl.gov/graphql/"\nVITE_GRAPHQL_WS_ENDPOINT="ws://nedm-macpro.lanl.gov/graphql/"' > '.env.local'
+
+echo "Build app"
+npm run build
+
+echo "Run new PM2 action"
+cp ./deploy-prod/ecosystem.config.js ecosystem.config.js
+pm2 start ecosystem.config.js -i 4

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -7,6 +7,7 @@ echo "Jump to app folder"
 cd $HOME/LANE/LANE-client
 pwd
 
+git checkout -- deploy-prod/deploy.sh
 git pull
 
 echo "Installing dependencies"

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -24,4 +24,4 @@ npm run build
 
 echo "Run new PM2 action"
 cp ./deploy-prod/ecosystem.config.js ecosystem.config.js
-pm2 start ecosystem.config.js -i 4
+pm2 start ecosystem.config.js -i 2

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -9,8 +9,7 @@ pwd
 
 git pull
 
-echo "Reinstalling dependencies"
-rm -rf node_modules
+echo "Installing dependencies"
 npm ci
 
 echo "Generate typescript from local files"

--- a/deploy-prod/ecosystem.config.js
+++ b/deploy-prod/ecosystem.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  apps: [
+    {
+      name: "LANE-client",
+      script: "npm",
+      args: "run staging",
+      watch: "dist",
+      instances: 2,
+      env: {
+        NODE_ENV: "production",
+      },
+      log_date_format: "YYYY-MM-DD HH:mm Z",
+    },
+  ],
+};

--- a/deploy-prod/lane.conf
+++ b/deploy-prod/lane.conf
@@ -7,10 +7,10 @@ upstream my_nodejs_upstream {
 
 server {
     listen 80;
-            # listen 443 ssl;
+            # listen 443 ssl; # For https, which is not configured
 
             server_name nemd-macpro.lanl.gov;
-            # ssl_certificate_key /etc/ssl/main.key;
+            # ssl_certificate_key /etc/ssl/main.key; # For https, which is not configured
             # ssl_certificate     /etc/ssl/main.crt;
 
         location / {

--- a/deploy-prod/lane.conf
+++ b/deploy-prod/lane.conf
@@ -1,0 +1,43 @@
+# This is the nginx configuration file located at `/etc/nginx/conf.d/lane.conf`
+
+upstream my_nodejs_upstream {
+        server 127.0.0.1:3000;
+        keepalive 64;
+}
+
+server {
+    listen 80;
+            # listen 443 ssl;
+
+            server_name nemd-macpro.lanl.gov;
+            # ssl_certificate_key /etc/ssl/main.key;
+            # ssl_certificate     /etc/ssl/main.crt;
+
+        location / {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $http_host;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_pass http://my_nodejs_upstream/;
+            proxy_redirect off;
+            proxy_read_timeout 240s;
+        }
+
+	# Proxy api requests
+	location /graphql/ {
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header Host $http_host;
+
+           proxy_http_version 1.1;
+           proxy_set_header Upgrade $http_upgrade;
+           proxy_set_header Connection "upgrade";
+	   proxy_pass http://127.0.0.1:8000/graphql/;
+           proxy_redirect off;
+           proxy_read_timeout 240s;
+	}
+}


### PR DESCRIPTION
## Changes
- Adds instructions to `CONTRIBUTING.md` for deployment to production
- Adds a copy of the Nginx configuration file used in production to the repository
- Adds a copy of the PM2 `ecosystem.config.js` file used in production to the repository
- Adds a script for deployment to production (will need to be run on the production server manually)
Closes #7 